### PR TITLE
[Boggle] Rotate board / handle error when submitting

### DIFF
--- a/app/boggle/page.tsx
+++ b/app/boggle/page.tsx
@@ -84,6 +84,7 @@ export default function Boggle() {
           <Box sx={{ display: "flex" }}>
             <BoggleCards
               squareGrid={squareGrid}
+              setSquareGrid={setSquareGrid}
               words={words}
               setWords={setWords}
               word={word}

--- a/app/components/BoggleCards.tsx
+++ b/app/components/BoggleCards.tsx
@@ -163,6 +163,7 @@ export default function BoggleCards(props: Props) {
                 sx={{
                   color: "#fff",
                   height: 56,
+                  width: 160,
                   backgroundColor: blue[500],
                   "&:hover": {
                     backgroundColor: blue[700],
@@ -177,35 +178,37 @@ export default function BoggleCards(props: Props) {
                 variant="outlined"
                 disabled
                 defaultValue={word}
-                sx={{ marginRight: 2, marginLeft: 2 }}
+                sx={{ marginRight: 2, marginLeft: 2, width: 220 }}
               />
-              <Button
-                sx={{
-                  color: "#fff",
-                  height: 56,
-                  backgroundColor: lightGreen[500],
-                  "&:hover": {
-                    backgroundColor: lightGreen[700],
-                  },
-                }}
-                onClick={submitWord}
-              >
-                Submit
-              </Button>
-              <Button
-                sx={{
-                  color: "#fff",
-                  marginLeft: 2,
-                  height: 56,
-                  backgroundColor: purple[500],
-                  "&:hover": {
-                    backgroundColor: purple[700],
-                  },
-                }}
-                onClick={handleRotateBoard}
-              >
-                Rotate
-              </Button>
+              <Box sx={{ display: "flex" }}>
+                <Button
+                  sx={{
+                    color: "#fff",
+                    height: 56,
+                    backgroundColor: lightGreen[500],
+                    "&:hover": {
+                      backgroundColor: lightGreen[700],
+                    },
+                  }}
+                  onClick={submitWord}
+                >
+                  Submit
+                </Button>
+                <Button
+                  sx={{
+                    color: "#fff",
+                    marginLeft: 2,
+                    height: 56,
+                    backgroundColor: purple[500],
+                    "&:hover": {
+                      backgroundColor: purple[700],
+                    },
+                  }}
+                  onClick={handleRotateBoard}
+                >
+                  Rotate
+                </Button>
+              </Box>
             </Box>
           </Box>
           <Box

--- a/app/components/BoggleCards.tsx
+++ b/app/components/BoggleCards.tsx
@@ -56,6 +56,7 @@ export default function BoggleCards(props: Props) {
   }
 
   function submitWord() {
+    if (!word) return handleError("Please select letters!");
     if (words.includes(word)) return handleError("Already guessed!");
 
     const newWords = [...words, word];

--- a/app/components/BoggleCards.tsx
+++ b/app/components/BoggleCards.tsx
@@ -1,12 +1,14 @@
 "use client";
 
 import { Box, Button, TextField, Card } from "@mui/material";
-import { indigo, lightGreen, blue, green } from "@mui/material/colors";
+import { indigo, lightGreen, blue, green, purple } from "@mui/material/colors";
 import { keyframes } from "@mui/system";
 import WordList from "./WordsList";
+import { useState } from "react";
 
 interface Props {
   squareGrid: string[][];
+  setSquareGrid: (squareGrid: string[][]) => void;
   word: string;
   setWord: (word: string) => void;
   words: string[];
@@ -20,6 +22,7 @@ interface Props {
 export default function BoggleCards(props: Props) {
   const {
     squareGrid,
+    setSquareGrid,
     words,
     setWords,
     word,
@@ -29,6 +32,8 @@ export default function BoggleCards(props: Props) {
     errMessage,
     setErrMessage,
   } = props;
+
+  const [rotate, setRotate] = useState<boolean>(false);
 
   function createWord(char: string, location: number[]) {
     if (invalidTileTapped(location))
@@ -85,6 +90,26 @@ export default function BoggleCards(props: Props) {
     }, 1500);
   }
 
+  function handleRotateBoard() {
+    resetWord();
+    setRotate(true);
+
+    let newGrid: string[][] = [];
+    for (let i = 0; i < 4; i++) {
+      let newRow: string[] = [];
+      for (let j = 3; j >= 0; j--) {
+        const char = squareGrid[j][i];
+        newRow.push(char);
+      }
+      newGrid.push(newRow);
+    }
+    setSquareGrid(newGrid);
+
+    setTimeout(() => {
+      setRotate(false);
+    }, 500);
+  }
+
   const shake = keyframes`
     from {
       transform: rotate(-3deg);
@@ -94,11 +119,27 @@ export default function BoggleCards(props: Props) {
     }
   `;
 
+  const rotateBoard = keyframes`
+    from {
+      transform: rotate(0deg);
+    } to {
+      transform: rotate(90deg);
+    }
+  `;
+
   return (
     <>
       <Box sx={{ display: "flex", margin: "auto" }}>
-        <Card sx={{ margin: 2, padding: 3 }}>
-          <Box sx={{ display: "flex" }}>
+        <Card
+          sx={{
+            margin: 2,
+            padding: 3,
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+          }}
+        >
+          <Box>
             <Box
               sx={{
                 margin: "auto",
@@ -127,7 +168,6 @@ export default function BoggleCards(props: Props) {
                 defaultValue={word}
                 sx={{ marginRight: 2, marginLeft: 2 }}
               />
-
               <Button
                 sx={{
                   color: "#fff",
@@ -141,6 +181,20 @@ export default function BoggleCards(props: Props) {
               >
                 Submit
               </Button>
+              <Button
+                sx={{
+                  color: "#fff",
+                  marginLeft: 2,
+                  height: 56,
+                  backgroundColor: purple[500],
+                  "&:hover": {
+                    backgroundColor: purple[700],
+                  },
+                }}
+                onClick={handleRotateBoard}
+              >
+                Rotate
+              </Button>
             </Box>
           </Box>
           <Box
@@ -151,6 +205,7 @@ export default function BoggleCards(props: Props) {
               display: "flex",
               flexDirection: "column",
               justifyContent: "space-evenly",
+              animation: rotate ? `${rotateBoard} 0.5s ease` : null,
             }}
           >
             {squareGrid.map((row, i) => {

--- a/app/components/BoggleCards.tsx
+++ b/app/components/BoggleCards.tsx
@@ -94,6 +94,13 @@ export default function BoggleCards(props: Props) {
     resetWord();
     setRotate(true);
 
+    setTimeout(() => {
+      newBoardAfterRotate();
+      setRotate(false);
+    }, 800);
+  }
+
+  function newBoardAfterRotate() {
     let newGrid: string[][] = [];
     for (let i = 0; i < 4; i++) {
       let newRow: string[] = [];
@@ -104,10 +111,6 @@ export default function BoggleCards(props: Props) {
       newGrid.push(newRow);
     }
     setSquareGrid(newGrid);
-
-    setTimeout(() => {
-      setRotate(false);
-    }, 500);
   }
 
   const shake = keyframes`
@@ -124,6 +127,14 @@ export default function BoggleCards(props: Props) {
       transform: rotate(0deg);
     } to {
       transform: rotate(90deg);
+    }
+  `;
+
+  const rotateTile = keyframes`
+    from {
+      transform: rotate(0deg);
+    } to {
+      transform: rotate(-90deg);
     }
   `;
 
@@ -199,13 +210,13 @@ export default function BoggleCards(props: Props) {
           </Box>
           <Box
             sx={{
-              bgcolor: "#E7C8DD",
+              bgcolor: "#eeeeee",
               height: 400,
               width: 400,
               display: "flex",
               flexDirection: "column",
               justifyContent: "space-evenly",
-              animation: rotate ? `${rotateBoard} 0.5s ease` : null,
+              animation: rotate ? `${rotateBoard} 0.8s ease` : null,
             }}
           >
             {squareGrid.map((row, i) => {
@@ -237,7 +248,9 @@ export default function BoggleCards(props: Props) {
                           animation:
                             !!errMessage && tileSelected(i, j)
                               ? `${shake} 0.5s infinite ease`
-                              : null,
+                              : rotate
+                              ? `${rotateTile} 0.8s ease`
+                              : "none",
                         }}
                       >
                         {char}


### PR DESCRIPTION
## Description ✏️ 
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
Fixes # (issue) -->
- The user should be able to rotate the board.
- The user shouldn't be able to submit an empty string.
## Type of change 👾

- [x] Bug fix (non-breaking change which fixes an issue) 
- [x] New feature (non-breaking change which adds functionality) 

## Solution 💡 
- A Rotate button was added to rotate the board and tiles:

https://github.com/gdomingu/lang-games/assets/60206746/4b967d5f-5079-46bc-a3b2-31b0e3d7dc45

- When submitting without selecting any tiles:
<img width="1470" alt="Screenshot 2024-03-13 at 1 45 08 PM" src="https://github.com/gdomingu/lang-games/assets/60206746/ca58209d-4320-47dd-96cb-19b16ad7123e">
sion without selecting any tiles pops up an error message.

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
<!--
- [ ] Test A
- [ ] Test B
-->
<!-- Add images if available -->
## Notes 📔
Closes https://github.com/gdomingu/lang-games/issues/9
Closes https://github.com/gdomingu/lang-games/issues/7